### PR TITLE
  v0.1.11: incognide engine jinx, pane focus fix, clickable sidebar s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incognide",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Explore the unknown, build the future, own your data.",
   "author": "Chris Agostino <info@npcworldwi.de>",
   "main": "src/main.js",

--- a/src/index.css
+++ b/src/index.css
@@ -205,6 +205,10 @@ body.light-mode {
 .theme-text-muted { color: var(--theme-text-muted) !important; }
 
 .theme-border { border-color: var(--theme-border) !important; }
+.theme-border.pane-active {
+    border-color: #3b82f6 !important;
+    box-shadow: 0 0 0 1px #3b82f6;
+}
 .theme-border-secondary { border-color: var(--theme-border-secondary) !important; }
 
 .theme-button {

--- a/src/npc_team/jinxes/examples/form_fill.jinx
+++ b/src/npc_team/jinxes/examples/form_fill.jinx
@@ -1,0 +1,33 @@
+jinx_name: form_fill
+description: >
+  Navigate to a URL in the active browser pane, then fill in a form field and submit.
+  Example: /form_fill url=https://google.com selector="textarea[name=q]" value="npcsh" submit=true
+inputs:
+  - url
+  - selector
+  - value
+  - { submit: false }
+steps:
+  - name: go_to_page
+    engine: incognide
+    action: navigate
+    args:
+      url: "{{ url }}"
+      paneId: active
+
+  - name: wait
+    engine: python
+    code: |
+      import time
+      time.sleep(1)
+      output = "Page loaded"
+
+  - name: fill_field
+    engine: incognide
+    action: browser_type
+    args:
+      selector: "{{ selector }}"
+      text: "{{ value }}"
+      clear: "true"
+      submit: "{{ submit }}"
+      paneId: active

--- a/src/npc_team/jinxes/examples/multi_pane_setup.jinx
+++ b/src/npc_team/jinxes/examples/multi_pane_setup.jinx
@@ -1,0 +1,30 @@
+jinx_name: multi_pane_setup
+description: >
+  Set up a multi-pane workspace: browser on the left, terminal on the right, chat below.
+  Example: /multi_pane_setup url=https://docs.python.org
+inputs:
+  - { url: "https://google.com" }
+steps:
+  - name: open_browser
+    engine: incognide
+    action: open_pane
+    args:
+      type: browser
+      url: "{{ url }}"
+      position: right
+
+  - name: open_terminal
+    engine: incognide
+    action: split_pane
+    args:
+      paneId: active
+      direction: right
+      type: terminal
+
+  - name: open_chat
+    engine: incognide
+    action: split_pane
+    args:
+      paneId: active
+      direction: down
+      type: chat

--- a/src/npc_team/jinxes/examples/screenshot_and_summarize.jinx
+++ b/src/npc_team/jinxes/examples/screenshot_and_summarize.jinx
@@ -1,0 +1,34 @@
+jinx_name: screenshot_and_summarize
+description: >
+  Take a screenshot of the active browser pane and get its text content,
+  then use an LLM to summarize the page.
+  Example: /screenshot_and_summarize
+inputs: []
+steps:
+  - name: get_page
+    engine: incognide
+    action: get_browser_content
+    args:
+      paneId: active
+
+  - name: screenshot
+    engine: incognide
+    action: browser_screenshot
+    args:
+      paneId: active
+
+  - name: summarize
+    engine: python
+    code: |
+      from npcpy.llm_funcs import get_llm_response
+      page_content = context.get('get_page', '')
+      if not page_content or 'Error' in str(page_content):
+          output = 'No browser content found. Open a browser pane first.'
+      else:
+          _model = npc.model if npc else 'gemma3:4b'
+          _provider = npc.provider if npc else 'ollama'
+          resp = get_llm_response(
+              f"Summarize this web page content in 3-5 bullet points:\n\n{page_content[:4000]}",
+              model=_model, provider=_provider
+          )
+          output = resp.get('response', str(resp)) if isinstance(resp, dict) else str(resp)

--- a/src/npc_team/jinxes/examples/web_scrape.jinx
+++ b/src/npc_team/jinxes/examples/web_scrape.jinx
@@ -1,0 +1,27 @@
+jinx_name: web_scrape
+description: >
+  Open a URL in a browser pane, wait for it to load, then extract the page content.
+  Example: /web_scrape url=https://news.ycombinator.com
+inputs:
+  - url
+steps:
+  - name: open_browser
+    engine: incognide
+    action: open_pane
+    args:
+      type: browser
+      url: "{{ url }}"
+      position: right
+
+  - name: wait_for_load
+    engine: python
+    code: |
+      import time
+      time.sleep(2)
+      output = "Waited for page load"
+
+  - name: scrape_content
+    engine: incognide
+    action: get_browser_content
+    args:
+      paneId: active

--- a/src/npc_team/jinxes/incognide.jinx
+++ b/src/npc_team/jinxes/incognide.jinx
@@ -1,0 +1,45 @@
+jinx_name: incognide
+description: Engine jinx for Incognide studio actions. Use as engine in other jinxes to call UI actions.
+inputs:
+  - { action: "" }
+  - { args: "" }
+steps:
+  - name: studio_action
+    engine: python
+    code: |
+      import requests, json as _json
+      _action = context.get('action', '').strip()
+      _args_raw = context.get('args', {})
+      if isinstance(_args_raw, str):
+          try:
+              _args = _json.loads(_args_raw)
+          except Exception:
+              _args = {}
+      else:
+          _args = dict(_args_raw) if _args_raw else {}
+      if not _action:
+          output = 'Error: action is required'
+      else:
+          _port = 5437
+          try:
+              import socket as _sock
+              for _p in [5337, 5437]:
+                  try:
+                      _s = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+                      _s.settimeout(0.3)
+                      _s.connect(('127.0.0.1', _p))
+                      _s.close()
+                      _port = _p
+                      break
+                  except Exception:
+                      pass
+          except Exception:
+              pass
+          try:
+              _r = requests.post(f'http://127.0.0.1:{_port}/api/studio/action',
+                  json={'action': _action, 'args': _args}, timeout=15)
+              _res = _r.json()
+              output = _json.dumps(_res, indent=2)
+              context['action_result'] = _res
+          except Exception as _e:
+              output = f"Error calling Incognide action '{_action}': {_e}"

--- a/src/npc_team/jinxes/ui/browser_back.jinx
+++ b/src/npc_team/jinxes/ui/browser_back.jinx
@@ -1,0 +1,10 @@
+jinx_name: browser_back
+description: Navigate back in a browser pane's history.
+inputs:
+  - { pane_id: "active" }
+steps:
+  - name: browser_back
+    engine: incognide
+    action: browser_back
+    args:
+      paneId: "{{ pane_id }}"

--- a/src/npc_team/jinxes/ui/browser_eval.jinx
+++ b/src/npc_team/jinxes/ui/browser_eval.jinx
@@ -1,0 +1,12 @@
+jinx_name: browser_eval
+description: Execute JavaScript code in a browser pane's page context.
+inputs:
+  - code
+  - { pane_id: "active" }
+steps:
+  - name: browser_eval
+    engine: incognide
+    action: browser_eval
+    args:
+      code: "{{ code }}"
+      paneId: "{{ pane_id }}"

--- a/src/npc_team/jinxes/ui/browser_forward.jinx
+++ b/src/npc_team/jinxes/ui/browser_forward.jinx
@@ -1,0 +1,10 @@
+jinx_name: browser_forward
+description: Navigate forward in a browser pane's history.
+inputs:
+  - { pane_id: "active" }
+steps:
+  - name: browser_forward
+    engine: incognide
+    action: browser_forward
+    args:
+      paneId: "{{ pane_id }}"

--- a/src/npc_team/jinxes/ui/get_browser_info.jinx
+++ b/src/npc_team/jinxes/ui/get_browser_info.jinx
@@ -1,0 +1,10 @@
+jinx_name: get_browser_info
+description: Get info about a browser pane (URL, title).
+inputs:
+  - { pane_id: "active" }
+steps:
+  - name: get_browser_info
+    engine: incognide
+    action: get_browser_info
+    args:
+      paneId: "{{ pane_id }}"

--- a/src/npc_team/jinxes/ui/run_terminal.jinx
+++ b/src/npc_team/jinxes/ui/run_terminal.jinx
@@ -1,5 +1,5 @@
 jinx_name: run_terminal
-description: Run a command in a terminal pane. Specify the command to execute and optionally the pane_id of the terminal (defaults to "active" for the currently active terminal pane).
+description: Run a command in a terminal pane. Defaults to the active terminal pane.
 inputs:
   - command
   - { pane_id: "active" }

--- a/src/npc_team/jinxes/ui/send_message.jinx
+++ b/src/npc_team/jinxes/ui/send_message.jinx
@@ -1,0 +1,12 @@
+jinx_name: send_message
+description: Send a message to a chat pane.
+inputs:
+  - message
+  - { pane_id: "active" }
+steps:
+  - name: send_message
+    engine: incognide
+    action: send_message
+    args:
+      message: "{{ message }}"
+      paneId: "{{ pane_id }}"

--- a/src/npc_team/jinxes/ui/split_pane.jinx
+++ b/src/npc_team/jinxes/ui/split_pane.jinx
@@ -1,0 +1,16 @@
+jinx_name: split_pane
+description: Split an existing pane to create a new pane next to it. Direction: right, left, up, down.
+inputs:
+  - direction
+  - pane_type
+  - { content_id: "" }
+  - { pane_id: "active" }
+steps:
+  - name: split_pane
+    engine: incognide
+    action: split_pane
+    args:
+      paneId: "{{ pane_id }}"
+      direction: "{{ direction }}"
+      type: "{{ pane_type }}"
+      path: "{{ content_id }}"

--- a/src/npc_team/jinxes/ui/zen_mode.jinx
+++ b/src/npc_team/jinxes/ui/zen_mode.jinx
@@ -1,0 +1,10 @@
+jinx_name: zen_mode
+description: Toggle zen mode (fullscreen) for a pane.
+inputs:
+  - { pane_id: "active" }
+steps:
+  - name: zen_mode
+    engine: incognide
+    action: zen_mode
+    args:
+      paneId: "{{ pane_id }}"

--- a/src/renderer/components/Enpistu.tsx
+++ b/src/renderer/components/Enpistu.tsx
@@ -782,6 +782,17 @@ const ChatInterface = ({ onRerunSetup }: { onRerunSetup?: () => void }) => {
     currentPathRef.current = currentPath;
     const activeContentPaneIdRef = useRef(activeContentPaneId);
     activeContentPaneIdRef.current = activeContentPaneId;
+
+    // Toggle blue outline on active pane via DOM — avoids re-rendering panes
+    useEffect(() => {
+        const prev = document.querySelector('[data-pane-id].pane-active');
+        if (prev) prev.classList.remove('pane-active');
+        if (activeContentPaneId) {
+            const el = document.querySelector(`[data-pane-id="${activeContentPaneId}"]`);
+            if (el) el.classList.add('pane-active');
+        }
+    }, [activeContentPaneId]);
+
     const [editorContextMenuPos, setEditorContextMenuPos] = useState(null);
     const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
     const [lockedPanes, setLockedPanes] = useState<Set<string>>(() => {
@@ -5110,18 +5121,20 @@ ${contextPrompt}`;
     }, []);
 
     const renderSkillsManagerPane = useCallback(({ nodeId }: { nodeId: string }) => {
+        const paneData = contentDataRef.current[nodeId];
         return (
             <SkillsManager
                 currentPath={currentPath}
                 embedded={true}
                 onOpenJinxEditor={() => createJinxPane?.()}
+                initialJinxName={paneData?.initialJinxName}
             />
         );
     }, [currentPath, createJinxPane]);
 
-    const createSkillsManagerPane = useCallback(async () => {
+    const createSkillsManagerPane = useCallback(async (jinxName?: string) => {
         const newPaneId = generateId();
-        contentDataRef.current[newPaneId] = { contentType: 'skills-manager', contentId: 'skills-manager' };
+        contentDataRef.current[newPaneId] = { contentType: 'skills-manager', contentId: 'skills-manager', initialJinxName: jinxName };
         addPaneOrTab(newPaneId);
     }, []);
 

--- a/src/renderer/components/LayoutNode.tsx
+++ b/src/renderer/components/LayoutNode.tsx
@@ -319,8 +319,6 @@ export const LayoutNode = memo(({ node, path, component: componentRef, contentVe
 
         const chatInputProps = getChatInputProps ? getChatInputProps(node.id) : null;
 
-        const isActive = node.id === activeContentPaneId;
-
         const [localDragOver, setLocalDragOver] = useState(false);
         const [localDropSide, setLocalDropSide] = useState<string | null>(null);
         const dragCounterRef = useRef(0);
@@ -1443,7 +1441,7 @@ export const LayoutNode = memo(({ node, path, component: componentRef, contentVe
 
         return (
             <div
-                className={`flex-1 flex flex-col border ${isActive ? 'border-blue-500 ring-1 ring-blue-500' : 'theme-border'}`}
+                className="flex-1 flex flex-col border theme-border"
                 style={{ position: 'relative', overflow: 'hidden' }}
                 data-pane-id={node.id}
                 data-pane-type={contentType}
@@ -1554,5 +1552,5 @@ export const LayoutNode = memo(({ node, path, component: componentRef, contentVe
         );
     }
     return null;
-}, (prev, next) => prev.node === next.node && prev.contentVersion === next.contentVersion && prev.activeContentPaneId === next.activeContentPaneId);
+}, (prev, next) => prev.node === next.node && prev.contentVersion === next.contentVersion);
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
     Loader2, ExternalLink, Link, Unlink, Filter, SortAsc, SortDesc, Table, Grid,
     List, Maximize2, Minimize2, Move, RotateCcw, ZoomIn, ZoomOut, Layers, Layout,
     Pause, Server, Mail, Cpu, Wifi, WifiOff, Power, PowerOff, Hash, AtSign, FlaskConical,
-    BrainCircuit, Music
+    BrainCircuit, Music, Square
 } from 'lucide-react';
 import CodeMirror from '@uiw/react-codemirror';
 import { javascript } from '@codemirror/lang-javascript';
@@ -1888,9 +1888,10 @@ const renderSidebarSkillNodes = (nodes: any[], teamKey: string, depth: number): 
             return (
                 <div
                     key={`${teamKey}-${name}-${idx}`}
-                    className="flex items-center gap-1 py-0.5 rounded hover:theme-bg-secondary text-[10px]"
+                    className="flex items-center gap-1 py-0.5 rounded hover:theme-bg-secondary text-[10px] cursor-pointer"
                     style={{ paddingLeft: `${depth * 10 + 6}px` }}
                     title={jinx.description || name}
+                    onClick={() => createSkillsManagerPane?.(name)}
                 >
                     {isSkill
                         ? <BookOpen size={9} className="text-purple-400 flex-shrink-0" />
@@ -6089,6 +6090,13 @@ return (
 
         {!bottomGridCollapsed && !sidebarCollapsed && (
         <div className="flex justify-center items-center gap-2 border-t theme-border" style={{ height: bottomBarHeight }}>
+            <button
+                onClick={() => createSkillsManagerPane?.()}
+                className="p-2 rounded-full hover:bg-teal-500/20 transition-all text-gray-400 hover:text-purple-400"
+                title="Skills & Jinxes"
+            >
+                <Zap size={18} />
+            </button>
             <button
                 onClick={() => setDownloadManagerOpen?.(true)}
                 className="p-2 rounded-full hover:bg-teal-500/20 transition-all text-gray-400 hover:text-blue-400"

--- a/src/renderer/components/SkillsManager.tsx
+++ b/src/renderer/components/SkillsManager.tsx
@@ -12,6 +12,7 @@ interface SkillsManagerProps {
     currentPath: string;
     embedded?: boolean;
     onOpenJinxEditor?: () => void;
+    initialJinxName?: string;
 }
 
 interface JinxItem {
@@ -113,7 +114,7 @@ function filterJinxes(jinxes: JinxItem[], query: string): JinxItem[] {
     );
 }
 
-const SkillsManager: React.FC<SkillsManagerProps> = ({ currentPath, embedded = true, onOpenJinxEditor }) => {
+const SkillsManager: React.FC<SkillsManagerProps> = ({ currentPath, embedded = true, onOpenJinxEditor, initialJinxName }) => {
 
     const [jinxesByTeam, setJinxesByTeam] = useState<{ npcsh: JinxItem[]; incognide: JinxItem[]; project: JinxItem[] }>({
         npcsh: [], incognide: [], project: [],
@@ -165,6 +166,14 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({ currentPath, embedded = t
     }, [currentPath]);
 
     useEffect(() => { loadAllJinxes(); }, [currentPath]);
+
+    // Auto-select jinx by name when opened from sidebar
+    useEffect(() => {
+        if (!initialJinxName || loading) return;
+        const all = [...jinxesByTeam.project, ...jinxesByTeam.incognide, ...jinxesByTeam.npcsh];
+        const match = all.find(j => j.jinx_name === initialJinxName);
+        if (match) setSelectedJinx(match);
+    }, [initialJinxName, loading, jinxesByTeam]);
 
     const trees = useMemo(() => {
         const filtered = {


### PR DESCRIPTION
…kills

  - Add incognide.jinx engine that bridges engine: incognide steps to StudioActions API
  - New UI jinxes: browser_eval, browser_back/forward, get_browser_info, split_pane, zen_mode, send_message
  - Example workflow jinxes: web_scrape, form_fill, multi_pane_setup, screenshot_and_summarize
  - Pane focus blue outline via DOM class toggle (no re-renders)
  - Sidebar jinx items open Skills Manager with jinx pre-selected
  - Fix missing Square icon import crash in MCP sidebar panel