### PR TITLE
fix: command injection, sidebar crash, gmail cookies, release permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/src/ipc/settings.js
+++ b/src/ipc/settings.js
@@ -443,18 +443,21 @@ function register(ctx) {
   const _getServiceInfoLocal = (unit) => {
     const platform = process.platform;
     const result = {};
+    // Sanitize unit name to prevent command injection — allow only alphanumeric, dots, hyphens, underscores
+    const safeUnit = String(unit).replace(/[^a-zA-Z0-9._\-]/g, '');
+    if (!safeUnit) return result;
     if (platform === 'linux') {
-      try { result.unit_file = execSync(`systemctl cat ${unit} 2>/dev/null`, { encoding: 'utf8', timeout: 5000 }); } catch {}
-      try { result.journal = execSync(`journalctl -u ${unit} --no-pager -n 100 2>/dev/null`, { encoding: 'utf8', timeout: 5000 }); } catch {}
+      try { result.unit_file = execSync(`systemctl cat ${safeUnit} 2>/dev/null`, { encoding: 'utf8', timeout: 5000 }); } catch {}
+      try { result.journal = execSync(`journalctl -u ${safeUnit} --no-pager -n 100 2>/dev/null`, { encoding: 'utf8', timeout: 5000 }); } catch {}
     } else if (platform === 'darwin') {
       // unit here is a launchd label
-      try { result.unit_file = execSync(`launchctl print system/${unit} 2>/dev/null || launchctl print gui/$(id -u)/${unit} 2>/dev/null`, { encoding: 'utf8', timeout: 5000 }); } catch {}
+      try { result.unit_file = execSync(`launchctl print system/${safeUnit} 2>/dev/null || launchctl print gui/$(id -u)/${safeUnit} 2>/dev/null`, { encoding: 'utf8', timeout: 5000 }); } catch {}
       try {
         // Try to find the plist file
         const searchDirs = ['/Library/LaunchDaemons', '/Library/LaunchAgents',
                             path.join(os.homedir(), 'Library/LaunchAgents')];
         for (const dir of searchDirs) {
-          const plistPath = path.join(dir, `${unit}.plist`);
+          const plistPath = path.join(dir, `${safeUnit}.plist`);
           if (fs.existsSync(plistPath)) {
             result.unit_file = fs.readFileSync(plistPath, 'utf8');
             break;
@@ -462,7 +465,7 @@ function register(ctx) {
         }
       } catch {}
     } else if (platform === 'win32') {
-      try { result.unit_file = execSync(`schtasks /query /tn "${unit}" /fo LIST /v`, { encoding: 'utf8', timeout: 5000 }); } catch {}
+      try { result.unit_file = execSync(`schtasks /query /tn "${safeUnit}" /fo LIST /v`, { encoding: 'utf8', timeout: 5000 }); } catch {}
     }
     return result;
   };

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -5569,7 +5569,9 @@ return (
                             <div className="border-t theme-border my-0.5" />
                             <div className="px-2 py-0.5 text-[8px] text-gray-500 uppercase">Agents</div>
                             {(() => {
-                                const agents = JSON.parse(localStorage.getItem('incognide_terminalAgents') || '[{"name":"claude","command":"claude"},{"name":"codex","command":"codex"},{"name":"opencode","command":"opencode"}]');
+                                let agents;
+                                try { agents = JSON.parse(localStorage.getItem('incognide_terminalAgents') || '[]'); } catch { agents = []; }
+                                if (!agents.length) agents = [{"name":"npcsh","command":"npcsh"},{"name":"opencode","command":"opencode"},{"name":"nanocoder","command":"nanocoder"},{"name":"claude","command":"claude"}];
                                 return agents.map((agent: any, idx: number) => (
                                     <button
                                         key={idx}

--- a/src/renderer/components/WebBrowserViewer.tsx
+++ b/src/renderer/components/WebBrowserViewer.tsx
@@ -477,10 +477,12 @@ const WebBrowserViewer = memo(({
 
         };
         const handleDidFailLoad = (e) => {
-            if (e.errorCode !== -3) {
-                setLoading(false);
-                setError(`Failed to load page (Error ${e.errorCode}: ${e.validatedURL})`);
-            }
+            // -3 = aborted (ignore), also ignore sub-frame failures (e.g. Google cookie rotation)
+            if (e.errorCode === -3 || e.isMainFrame === false) return;
+            // Ignore Google's RotateCookiesPage failures — background cookie exchange for multi-account sessions
+            if (e.validatedURL && e.validatedURL.includes('accounts.google.com/RotateCookiesPage')) return;
+            setLoading(false);
+            setError(`Failed to load page (Error ${e.errorCode}: ${e.validatedURL})`);
         };
 
         const handleWebviewContextMenu = (e) => {


### PR DESCRIPTION
## Summary
- Sanitize unit param in `_getServiceInfoLocal()` to prevent command injection
- Wrap localStorage JSON.parse in try/catch for terminal agents in Sidebar
- Default terminal agents: npcsh, opencode, nanocoder, claude
- Ignore Google RotateCookiesPage sub-frame failures in WebBrowserViewer
- Add `permissions: contents: write` to build.yaml so release artifact uploads work