### PR TITLE
v0.1.29: extract music handlers, fix CI duplicate-channel detection, fix critical bug in v0.1.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,14 +215,74 @@ jobs:
         env:
           npm_config_optional: true
 
-      - name: Verify main.js syntax
-        run: node -e "require('./src/main.js')" 2>&1 || true
-
       - name: Verify preload.js syntax
-        run: node -e "require('./src/preload.js')" 2>&1 || true
+        run: node --check src/preload.js
 
-      - name: Verify IPC settings handlers load
-        run: node -e "require('./src/ipc/settings.js')" 2>&1 || true
+      - name: Verify all IPC modules syntax
+        shell: bash
+        run: |
+          for f in src/ipc/*.js; do
+            node --check "$f"
+          done
+
+      - name: Smoke-test registerAll (catches duplicate ipcMain.handle channels)
+        shell: bash
+        run: |
+          node -e "
+            const registered = new Set();
+            const stub = () => {};
+            const ipcMain = {
+              handle: (channel) => {
+                if (registered.has(channel)) {
+                  throw new Error('Duplicate ipcMain.handle for channel: ' + channel);
+                }
+                registered.add(channel);
+              },
+              on: stub,
+              removeHandler: stub,
+              removeAllListeners: stub,
+            };
+            const { registerAll } = require('./src/ipc');
+            registerAll({
+              ipcMain,
+              getMainWindow: () => null,
+              dbQuery: async () => [],
+              callBackendApi: async () => ({}),
+              BACKEND_URL: 'http://127.0.0.1:5337',
+              BACKEND_PORT: 5337,
+              log: () => {},
+              logBackend: () => {},
+              generateId: () => 'id',
+              activeStreams: new Map(),
+              DEFAULT_CONFIG: {},
+              app: { getAppPath: () => process.cwd(), getPath: () => process.cwd() },
+              IS_DEV_MODE: true,
+              cronJobs: new Map(),
+              daemons: new Map(),
+              scheduleCronJob: () => {},
+              deviceConfig: {},
+              updateDeviceConfig: () => {},
+              getOrCreateDeviceId: () => 'dev',
+              needsFirstRunSetup: () => false,
+              saveBackendPythonPath: () => {},
+              markSetupComplete: () => {},
+              getBackendPythonPath: () => null,
+              getUserProfile: () => ({}),
+              saveUserProfile: () => {},
+              registerGlobalShortcut: () => {},
+              backendProcess: null,
+              killBackendProcess: () => {},
+              ensureUserDataDirectory: () => {},
+              waitForServer: async () => {},
+              logsDir: '/tmp',
+              electronLogPath: '/tmp/electron.log',
+              backendLogPath: '/tmp/backend.log',
+              ensureTablesExist: async () => {},
+              appDir: process.cwd() + '/src',
+              NPCSH_BASE: '/tmp/.npcsh',
+            });
+            console.log('OK: registered ' + registered.size + ' unique channels');
+          "
 
       - name: Test GGUF path detection includes Windows paths
         if: runner.os == 'Windows'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incognide",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Explore the unknown, build the future, own your data.",
   "author": "Chris Agostino <info@npcworldwi.de>",
   "main": "src/main.js",

--- a/src/ipc/chat.js
+++ b/src/ipc/chat.js
@@ -250,7 +250,6 @@ function register(ctx) {
   }
 
   const shellOutImageGen = (pythonPath, payload) => shellOutHelper(pythonPath, 'run_image_gen.py', payload);
-  const shellOutMusicGen = (pythonPath, payload) => shellOutHelper(pythonPath, 'run_music_gen.py', payload);
 
   ipcMain.handle('getAvailableModels', async (event, currentPath) => {
 
@@ -441,120 +440,6 @@ function register(ctx) {
     const paths = result.paths || [];
     const filenames = paths.map(p => path.basename(p));
     return { images: paths.map(p => `file://${p}`), filenames, generation_id: generateId() };
-  });
-
-  ipcMain.handle('load_demo_tracks', async () => {
-    try {
-      const fs = require('fs');
-      const path = require('path');
-      const { app } = require('electron');
-      const candidates = [
-        path.resolve(__dirname, '..', '..', 'assets', 'demo_audio'),
-        path.join(process.resourcesPath || '', 'assets', 'demo_audio'),
-        path.join(app.getAppPath(), 'assets', 'demo_audio'),
-      ];
-      const dir = candidates.find(p => fs.existsSync(p));
-      if (!dir) return { success: false, error: 'demo_audio directory not found in app resources' };
-      const files = fs.readdirSync(dir)
-        .filter(n => /\.(wav|mp3|ogg|flac|m4a|aac|aiff)$/i.test(n))
-        .map(n => ({ name: n, path: path.join(dir, n) }));
-      return { success: true, tracks: files, dir };
-    } catch (error) {
-      log('Error loading demo tracks:', error);
-      return { success: false, error: error.message };
-    }
-  });
-
-  ipcMain.handle('generate_music', async (event, { prompt, provider, model, duration, currentPath, workspacePath, baseFilename, apiKey }) => {
-    log(`[Main Process] Generate music: "${prompt}" provider=${provider} model=${model} dur=${duration}s`);
-    if (!prompt) return { success: false, error: 'Prompt is required' };
-
-    const p = (provider || 'local').toLowerCase();
-    const isLocal = ['local', 'musicgen', 'transformers', 'meta'].includes(p);
-
-    if (!isLocal) {
-      try {
-        const response = await fetch(`${BACKEND_URL}/api/generate_music`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ prompt, provider, model, duration, currentPath }),
-        });
-        const data = await response.json();
-        if (!response.ok || !data.success) {
-          return { success: false, error: data.error || `HTTP ${response.status}` };
-        }
-        return data;
-      } catch (error) {
-        log('Error generating music via backend:', error);
-        return { success: false, error: error.message || 'Music generation failed' };
-      }
-    }
-
-    const outputDir = currentPath && currentPath.startsWith('~')
-      ? path.join(os.homedir(), currentPath.slice(1).replace(/^\//, ''))
-      : (currentPath || path.join(os.homedir(), '.npcsh', 'audio'));
-
-    const python = await resolveWorkspacePython(workspacePath);
-    if (!python) {
-      return { success: false, error: 'No Python environment configured for this workspace. Open Team Management → Python Env and create a venv with npcpy + torch + transformers installed.' };
-    }
-
-    const result = await shellOutMusicGen(python, {
-      prompt,
-      provider,
-      model,
-      duration,
-      output_dir: outputDir,
-      base_filename: baseFilename,
-      api_key: apiKey,
-    });
-    if (!result.success) {
-      log('Music generation (shell-out) failed:', result.error);
-      return { success: false, error: result.error };
-    }
-    return { success: true, path: result.path, url: `file://${result.path}`, format: result.format, provider: result.provider, model: result.model };
-  });
-
-  ipcMain.handle('load_demo_tracks', async () => {
-    try {
-      const fs = require('fs');
-      const path = require('path');
-      const { app } = require('electron');
-      const candidates = [
-        path.resolve(__dirname, '..', '..', 'assets', 'demo_audio'),
-        path.join(process.resourcesPath || '', 'assets', 'demo_audio'),
-        path.join(app.getAppPath(), 'assets', 'demo_audio'),
-      ];
-      const dir = candidates.find(p => fs.existsSync(p));
-      if (!dir) return { success: false, error: 'demo_audio directory not found in app resources' };
-      const files = fs.readdirSync(dir)
-        .filter(n => /\.(wav|mp3|ogg|flac|m4a|aac|aiff)$/i.test(n))
-        .map(n => ({ name: n, path: path.join(dir, n) }));
-      return { success: true, tracks: files, dir };
-    } catch (error) {
-      log('Error loading demo tracks:', error);
-      return { success: false, error: error.message };
-    }
-  });
-
-  ipcMain.handle('generate_music', async (event, { prompt, provider, model, duration, currentPath }) => {
-    log(`[Main Process] Generate music: "${prompt}" provider=${provider} model=${model} dur=${duration}s`);
-    if (!prompt) return { success: false, error: 'Prompt is required' };
-    try {
-      const response = await fetch(`${BACKEND_URL}/api/generate_music`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt, provider, model, duration, currentPath }),
-      });
-      const data = await response.json();
-      if (!response.ok || !data.success) {
-        return { success: false, error: data.error || `HTTP ${response.status}` };
-      }
-      return data;
-    } catch (error) {
-      log('Error generating music:', error);
-      return { success: false, error: error.message || 'Music generation failed' };
-    }
   });
 
   ipcMain.handle('deleteMessage', async (_, { conversationId, messageId }) => {

--- a/src/ipc/index.js
+++ b/src/ipc/index.js
@@ -6,6 +6,7 @@ const git = require('./git');
 const database = require('./database');
 const jupyter = require('./jupyter');
 const chat = require('./chat');
+const music = require('./music');
 const npc = require('./npc');
 const filesystem = require('./filesystem');
 const settings = require('./settings');
@@ -24,6 +25,7 @@ function registerAll(ctx) {
   database.register(fullCtx);
   jupyter.register(fullCtx);
   chat.register(fullCtx);
+  music.register(fullCtx);
   npc.register(fullCtx);
   filesystem.register(fullCtx);
   settings.register(fullCtx);

--- a/src/ipc/music.js
+++ b/src/ipc/music.js
@@ -1,0 +1,144 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const fetch = require('node-fetch');
+const { spawn } = require('child_process');
+
+function register(ctx) {
+  const {
+    ipcMain,
+    BACKEND_URL,
+    log,
+    readPythonEnvConfig,
+    resolvePythonPath,
+  } = ctx;
+
+  async function resolveWorkspacePython(workspacePath) {
+    if (!workspacePath) return null;
+    try {
+      const config = await readPythonEnvConfig();
+      const envConfig = config?.workspaces?.[workspacePath];
+      if (!envConfig) return null;
+      const resolved = await resolvePythonPath(workspacePath, envConfig);
+      return resolved?.pythonPath || null;
+    } catch {
+      return null;
+    }
+  }
+
+  function resolveHelperScript(scriptName) {
+    const { app } = require('electron');
+    const candidates = [
+      path.resolve(__dirname, '..', '..', 'resources', scriptName),
+      path.join(process.resourcesPath || '', scriptName),
+      path.join(app.getAppPath(), 'resources', scriptName),
+    ];
+    return candidates.find(p => { try { return fs.existsSync(p); } catch { return false; } });
+  }
+
+  function shellOutHelper(pythonPath, scriptName, payload) {
+    return new Promise((resolve) => {
+      const scriptPath = resolveHelperScript(scriptName);
+      if (!scriptPath) {
+        resolve({ success: false, error: `${scriptName} not found in resources` });
+        return;
+      }
+      const proc = spawn(pythonPath, [scriptPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+      let stdout = '';
+      let stderr = '';
+      proc.stdout.on('data', d => { stdout += d.toString(); });
+      proc.stderr.on('data', d => { stderr += d.toString(); });
+      proc.on('error', (err) => resolve({ success: false, error: `Failed to spawn ${pythonPath}: ${err.message}` }));
+      proc.on('close', (code) => {
+        if (code !== 0 && !stdout) {
+          resolve({ success: false, error: stderr || `${scriptName} exited with code ${code}` });
+          return;
+        }
+        try {
+          const last = stdout.trim().split('\n').pop();
+          resolve(JSON.parse(last));
+        } catch (err) {
+          resolve({ success: false, error: `Could not parse helper output: ${err.message}. stderr: ${stderr}` });
+        }
+      });
+      try {
+        proc.stdin.write(JSON.stringify(payload));
+        proc.stdin.end();
+      } catch (err) {
+        resolve({ success: false, error: `Failed to write to helper stdin: ${err.message}` });
+      }
+    });
+  }
+
+  ipcMain.handle('load_demo_tracks', async () => {
+    try {
+      const { app } = require('electron');
+      const candidates = [
+        path.resolve(__dirname, '..', '..', 'assets', 'demo_audio'),
+        path.join(process.resourcesPath || '', 'assets', 'demo_audio'),
+        path.join(app.getAppPath(), 'assets', 'demo_audio'),
+      ];
+      const dir = candidates.find(p => fs.existsSync(p));
+      if (!dir) return { success: false, error: 'demo_audio directory not found in app resources' };
+      const files = fs.readdirSync(dir)
+        .filter(n => /\.(wav|mp3|ogg|flac|m4a|aac|aiff)$/i.test(n))
+        .map(n => ({ name: n, path: path.join(dir, n) }));
+      return { success: true, tracks: files, dir };
+    } catch (error) {
+      log('Error loading demo tracks:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
+  ipcMain.handle('generate_music', async (event, { prompt, provider, model, duration, currentPath, workspacePath, baseFilename, apiKey }) => {
+    log(`[Main Process] Generate music: "${prompt}" provider=${provider} model=${model} dur=${duration}s`);
+    if (!prompt) return { success: false, error: 'Prompt is required' };
+
+    const p = (provider || 'local').toLowerCase();
+    const isLocal = ['local', 'musicgen', 'transformers', 'meta'].includes(p);
+
+    if (!isLocal) {
+      try {
+        const response = await fetch(`${BACKEND_URL}/api/generate_music`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt, provider, model, duration, currentPath }),
+        });
+        const data = await response.json();
+        if (!response.ok || !data.success) {
+          return { success: false, error: data.error || `HTTP ${response.status}` };
+        }
+        return data;
+      } catch (error) {
+        log('Error generating music via backend:', error);
+        return { success: false, error: error.message || 'Music generation failed' };
+      }
+    }
+
+    const outputDir = currentPath && currentPath.startsWith('~')
+      ? path.join(os.homedir(), currentPath.slice(1).replace(/^\//, ''))
+      : (currentPath || path.join(os.homedir(), '.npcsh', 'audio'));
+
+    const python = await resolveWorkspacePython(workspacePath);
+    if (!python) {
+      return { success: false, error: 'No Python environment configured for this workspace. Open Team Management → Python Env and create a venv with npcpy + torch + transformers installed.' };
+    }
+
+    const result = await shellOutHelper(python, 'run_music_gen.py', {
+      prompt,
+      provider,
+      model,
+      duration,
+      output_dir: outputDir,
+      base_filename: baseFilename,
+      api_key: apiKey,
+    });
+    if (!result.success) {
+      log('Music generation (shell-out) failed:', result.error);
+      return { success: false, error: result.error };
+    }
+    return { success: true, path: result.path, url: `file://${result.path}`, format: result.format, provider: result.provider, model: result.model };
+  });
+}
+
+module.exports = { register };


### PR DESCRIPTION
- Move load_demo_tracks and generate_music out of chat.js into new src/ipc/music.js
- Remove duplicate ipcMain.handle registrations that short-circuited the registerAll chain and broke settings/npc/filesystem handlers
- Harden CI: drop "|| true" masks, syntax-check all ipc/*.js, add registerAll smoke test with stubbed ipcMain that fails on duplicate channels
- Bump version to 0.1.29