### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,22 +1,30 @@
 name: Attach Artifacts to Release
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to attach (e.g., 0.1.32)'
+        required: true
+        type: string
 
 jobs:
   attach-artifacts:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Extract version from release tag
+      - name: Extract version
         id: version
         run: |
-          # Strip leading 'v' from tag if present (e.g. v0.1.18 -> 0.1.18)
-          TAG="${{ github.event.release.tag_name }}"
-          VERSION="${TAG#v}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${{ inputs.version }}"
+            TAG="v${{ inputs.version }}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Release tag: $TAG, version: $VERSION"
@@ -59,7 +67,7 @@ jobs:
           for file in artifacts/*; do
             if [ -f "$file" ]; then
               filesize=$(stat -c%s "$file")
-              if [ "$filesize" -gt 1000 ]; then
+              if [ $filesize -gt 1000 ]; then
                 echo "Attaching $(basename "$file") ($filesize bytes) to release $TAG"
                 gh release upload "$TAG" "$file" --repo "$GITHUB_REPOSITORY" --clobber
                 ATTACHED=$((ATTACHED + 1))
@@ -69,8 +77,8 @@ jobs:
             fi
           done
           echo "Attached $ATTACHED artifacts to release $TAG"
-          if [ "$ATTACHED" -eq 0 ]; then
-            echo "::warning::No artifacts were attached. The build may not have completed yet for version ${{ steps.version.outputs.version }}."
+          if [ $ATTACHED -eq 0 ]; then
+            echo "::warning::No artifacts were attached."
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the release workflow to trigger on release events instead of push to main. Also adds workflow_dispatch input for manual runs.