### PR TITLE
fix windows path separator failures in unit tests

### DIFF
--- a/tests/unit/daemon.test.ts
+++ b/tests/unit/daemon.test.ts
@@ -275,15 +275,15 @@ describe('daemon pure functions', () => {
       case 'uv': {
         const binDir = isWin ? 'Scripts' : 'bin';
         const venvPath = pythonEnvConfig.venvPath || '.venv';
-        return path.join(workspacePath, venvPath, binDir, pythonBin);
+        return path.posix.join(workspacePath, venvPath, binDir, pythonBin);
       }
       case 'pyenv': {
-        const pyenvRoot = process.env.PYENV_ROOT || path.join(os.homedir(), '.pyenv');
-        return path.join(pyenvRoot, 'versions', pythonEnvConfig.pyenvVersion, 'bin', pythonBin);
+        const pyenvRoot = process.env.PYENV_ROOT || path.posix.join(os.homedir(), '.pyenv');
+        return path.posix.join(pyenvRoot, 'versions', pythonEnvConfig.pyenvVersion, 'bin', pythonBin);
       }
       case 'conda': {
-        const condaRoot = pythonEnvConfig.condaRoot || path.join(os.homedir(), 'anaconda3');
-        return path.join(condaRoot, 'envs', pythonEnvConfig.condaEnv, 'bin', pythonBin);
+        const condaRoot = pythonEnvConfig.condaRoot || path.posix.join(os.homedir(), 'anaconda3');
+        return path.posix.join(condaRoot, 'envs', pythonEnvConfig.condaEnv, 'bin', pythonBin);
       }
       case 'custom':
         return pythonEnvConfig.customPath;

--- a/tests/unit/incognideHome.test.ts
+++ b/tests/unit/incognideHome.test.ts
@@ -335,10 +335,10 @@ describe('INCOGNIDE_HOME path replacement', () => {
   it('replaces .npcsh/incognide paths with INCOGNIDE_HOME', () => {
     const INCOGNIDE_HOME = '/home/user/.incognide';
     const paths = {
-      venv: path.join(INCOGNIDE_HOME, 'venv'),
-      data: path.join(INCOGNIDE_HOME, 'data'),
-      npc_team: path.join(INCOGNIDE_HOME, 'npc_team'),
-      logs: path.join(INCOGNIDE_HOME, 'logs'),
+      venv: path.posix.join(INCOGNIDE_HOME, 'venv'),
+      data: path.posix.join(INCOGNIDE_HOME, 'data'),
+      npc_team: path.posix.join(INCOGNIDE_HOME, 'npc_team'),
+      logs: path.posix.join(INCOGNIDE_HOME, 'logs'),
     };
 
     expect(paths.venv).toBe('/home/user/.incognide/venv');
@@ -349,7 +349,7 @@ describe('INCOGNIDE_HOME path replacement', () => {
 
   it('INCOGNIDE_TEAM_PATH uses INCOGNIDE_HOME', () => {
     const INCOGNIDE_HOME = '/home/user/.incognide';
-    const INCOGNIDE_TEAM_PATH = path.join(INCOGNIDE_HOME, 'npc_team');
+    const INCOGNIDE_TEAM_PATH = path.posix.join(INCOGNIDE_HOME, 'npc_team');
 
     expect(INCOGNIDE_TEAM_PATH).toBe('/home/user/.incognide/npc_team');
   });


### PR DESCRIPTION
- daemon.test.ts: use path.posix.join for resolvePythonPath so conda/pyenv/venv expectations match across platforms
- incognideHome.test.ts: use path.posix.join for INCOGNIDE_HOME conceptual path assertions