### PR TITLE
fix: persist tabs/panes mode, terminal source profile, and recent folders across restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incognide",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Explore the unknown, build the future, own your data.",
   "author": "Chris Agostino <info@npcworldwi.de>",
   "license": "MIT",

--- a/src/main.js
+++ b/src/main.js
@@ -120,6 +120,35 @@ function loadShellEnv() {
 }
 loadShellEnv();
 
+const RECENT_PATHS_FILE = path.join(INCOGNIDE_HOME, 'recent_paths.json');
+
+function loadRecentPaths() {
+  try {
+    if (fs.existsSync(RECENT_PATHS_FILE)) {
+      const data = JSON.parse(fs.readFileSync(RECENT_PATHS_FILE, 'utf-8'));
+      if (Array.isArray(data)) return data;
+    }
+  } catch (e) {
+    console.error('[RECENT_PATHS] Error loading:', e.message);
+  }
+  return [];
+}
+
+function saveRecentPaths(paths) {
+  try {
+    fs.writeFileSync(RECENT_PATHS_FILE, JSON.stringify(paths, null, 2));
+  } catch (e) {
+    console.error('[RECENT_PATHS] Error saving:', e.message);
+  }
+}
+
+function addRecentPath(newPath) {
+  const paths = loadRecentPaths();
+  const filtered = paths.filter(p => p !== newPath);
+  filtered.unshift(newPath);
+  saveRecentPaths(filtered.slice(0, 20));
+}
+
 if (IS_DEV_MODE) {
   app.setPath('userData', path.join(INCOGNIDE_HOME, 'dev'));
 } else {
@@ -2543,6 +2572,24 @@ registerAll({
 });
 
 // Generic proxy fetch — bypasses CORS for renderer requests to external APIs
+
+// Recent paths IPC handlers
+ipcMain.handle('get-recent-paths', async () => {
+  return loadRecentPaths();
+});
+
+ipcMain.handle('set-recent-paths', async (_event, paths) => {
+  if (Array.isArray(paths)) {
+    saveRecentPaths(paths.slice(0, 20));
+  }
+});
+
+ipcMain.handle('add-recent-path', async (_event, newPath) => {
+  if (newPath) {
+    addRecentPath(newPath);
+  }
+});
+
 ipcMain.handle('proxy-fetch', async (_event, url, options = {}) => {
   try {
     const resp = await fetch(url, {

--- a/src/preload.js
+++ b/src/preload.js
@@ -74,6 +74,9 @@ readDocxContent: (filePath) =>
     loadDemoTracks: () => ipcRenderer.invoke('load_demo_tracks'),
 
     openNewWindow: (path, options) => ipcRenderer.invoke('open-new-window', path, options),
+    addRecentPath: (newPath) => ipcRenderer.invoke('add-recent-path', newPath),
+    setRecentPaths: (paths) => ipcRenderer.invoke('set-recent-paths', paths),
+    getRecentPaths: () => ipcRenderer.invoke('get-recent-paths'),
     getWindowCount: () => ipcRenderer.invoke('get-window-count'),
     getAllWindowsInfo: () => ipcRenderer.invoke('get-all-windows-info'),
     closeWindowById: (windowId) => ipcRenderer.invoke('close-window-by-id', windowId),

--- a/src/renderer/components/Enpistu.tsx
+++ b/src/renderer/components/Enpistu.tsx
@@ -324,8 +324,24 @@ const ChatInterface = ({ onRerunSetup }: { onRerunSetup?: () => void }) => {
 
     // Open mode (pane vs tab) - must be before useLayoutManager so the ref can be passed
     const [openMode, setOpenMode] = useState<'pane' | 'tab'>(() => (localStorage.getItem('incognide_openMode') as 'pane' | 'tab') || 'pane');
+    const [recentPaths, setRecentPaths] = useState<string[]>([]);
     const openModeRef = useRef(openMode);
     openModeRef.current = openMode;
+
+    // Load recent paths from file-based storage on mount
+    useEffect(() => {
+        const loadRecent = async () => {
+            try {
+                const filePaths = await (window as any).api?.getRecentPaths?.();
+                if (filePaths && Array.isArray(filePaths) && filePaths.length > 0) {
+                    setRecentPaths(filePaths);
+                    // Also sync to localStorage so PathSwitcher/Sidebar see them
+                    localStorage.setItem('incognide-recent-paths', JSON.stringify(filePaths));
+                }
+            } catch (e) {}
+        };
+        loadRecent();
+    }, []);
 
     // Pane update emitter - must be before useLayoutManager so it can notify specific panes
     const paneUpdateEmitter = useRef(new EventTarget()).current;
@@ -1551,6 +1567,34 @@ const handleOpenHelpEvent = () => createHelpPaneRef.current?.();
             window.removeEventListener('beforeunload', saveCurrentWorkspace);
         };
     }, [currentPath, rootLayoutNode, activeContentPaneId]);
+    // Sync recent paths to file storage whenever localStorage changes
+    useEffect(() => {
+        const syncToFile = async () => {
+            try {
+                const stored = localStorage.getItem('incognide-recent-paths');
+                if (stored) {
+                    const paths = JSON.parse(stored);
+                    if (Array.isArray(paths) && paths.length > 0) {
+                        setRecentPaths(paths);
+                        await (window as any).api?.setRecentPaths?.(paths);
+                    }
+                }
+            } catch (e) {}
+        };
+        // Listen for storage changes from other windows
+        const handleStorage = (e: StorageEvent) => {
+            if (e.key === 'incognide-recent-paths') {
+                try {
+                    const paths = e.newValue ? JSON.parse(e.newValue) : [];
+                    setRecentPaths(paths);
+                } catch {}
+            }
+        };
+        window.addEventListener('storage', handleStorage);
+        syncToFile();
+        return () => window.removeEventListener('storage', handleStorage);
+    }, []);
+
 
     // Expose workspace serialization for cross-window preset saving
     useEffect(() => {
@@ -5782,6 +5826,8 @@ ${contextPrompt}`;
                 const filtered = recent.filter(p => p !== currentPath);
                 filtered.unshift(currentPath);
                 localStorage.setItem('incognide-recent-paths', JSON.stringify(filtered.slice(0, 20)));
+                // Also sync to file-based storage for cross-window persistence
+                (window as any).api?.addRecentPath?.(currentPath);
             } catch (e) {}
         }
     }, [currentPath]);
@@ -8986,8 +9032,6 @@ const renderMainContent = () => {
                                 </button>
                                 {(() => {
                                     try {
-                                        const stored = localStorage.getItem('incognide-recent-paths');
-                                        const recentPaths: string[] = stored ? JSON.parse(stored) : [];
                                         if (recentPaths.length === 0) return null;
                                         return (
                                             <div className="w-full mt-2 text-left">

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -4,7 +4,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal as TerminalIcon, Code, Sparkles, Settings, X, Type, Palette } from 'lucide-react';
 import '@xterm/xterm/css/xterm.css';
 
-const SHELL_PROMPT_KEY = 'incognide-shell-profile-prompted';
+const AUTO_SOURCE_KEY = 'incognide-auto-source-profile';
 
 const MAX_TERMINAL_CONTEXT_LINES = 100;
 
@@ -329,12 +329,12 @@ const TerminalView = ({ nodeId, contentDataRef, currentPath, activeContentPaneId
             const cmd = getShellProfileCommand();
             window.api.writeToTerminal({ id: terminalId, data: cmd + '\n' });
         }
-        localStorage.setItem(SHELL_PROMPT_KEY, 'true');
+        localStorage.setItem(AUTO_SOURCE_KEY, 'true');
         setShowShellPrompt(false);
     }, [terminalId, getShellProfileCommand]);
 
     const handleDismissPrompt = useCallback(() => {
-        localStorage.setItem(SHELL_PROMPT_KEY, 'true');
+        localStorage.setItem(AUTO_SOURCE_KEY, 'false');
         setShowShellPrompt(false);
     }, []);
 
@@ -802,8 +802,11 @@ const TerminalView = ({ nodeId, contentDataRef, currentPath, activeContentPaneId
                         window.api.writeToTerminal({ id: terminalId, data: '\r' });
                     }
 
-                    const hasBeenPrompted = localStorage.getItem(SHELL_PROMPT_KEY);
-                    if (!hasBeenPrompted && result.shell === 'system') {
+                    const autoSource = localStorage.getItem(AUTO_SOURCE_KEY);
+                    if (autoSource === 'true' && isSessionReady.current && terminalId) {
+                        const cmd = getShellProfileCommand();
+                        window.api.writeToTerminal({ id: terminalId, data: cmd + '\n' });
+                    } else if (autoSource !== 'false' && autoSource !== 'true' && result.shell === 'system') {
                         setShowShellPrompt(true);
                     }
                 } else {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,120 @@
+# Test Suite Overview
+
+## PDF Tests
+
+This directory contains comprehensive tests for PDF functionality in Incognide.
+
+### Test Files
+
+#### 1. `pdfDatabase.test.ts`
+Tests for PDF database operations including:
+- Table schema validation
+- Adding/retrieving/updating/deleting highlights
+- Adding/retrieving/updating/deleting drawings
+- Multi-page drawing operations
+- Cross-file isolation
+- Data integrity
+
+**Coverage**: 20 tests
+
+#### 2. `pdfExport.test.ts`
+Tests for PDF export utilities including:
+- Color parsing (RGBA and hex formats)
+- SVG path parsing
+- Typed signature format parsing
+- Error handling for edge cases
+- Empty data handling
+
+**Coverage**: 20 tests
+
+#### 3. `pdfIntegration.test.ts`
+End-to-end workflow tests including:
+- Full annotation workflow (load -> highlight -> draw -> export)
+- Multiple PDF file handling
+- Large dataset performance (100+ annotations)
+- Special character handling in annotations
+- Database persistence verification
+
+**Coverage**: 4 tests
+
+#### 4. `SignatureModal.test.tsx`
+Component tests for the signature modal including:
+- Render/unrender behavior
+- Tab switching (Draw/Type)
+- Canvas and color picker presence
+- Save button state validation
+- Close/cancel functionality
+
+**Coverage**: 8 tests
+
+### Running Tests
+
+Run all PDF tests:
+```bash
+npm test -- tests/unit/pdf --run
+```
+
+Run individual test files:
+```bash
+npm test -- tests/unit/pdfDatabase.test.ts --run
+npm test -- tests/unit/pdfExport.test.ts --run
+npm test -- tests/unit/pdfIntegration.test.ts --run
+npm test -- tests/unit/SignatureModal.test.tsx --run
+```
+
+Or use the test runner script:
+```bash
+node scripts/run-pdf-tests.js
+```
+
+### Regression Prevention
+
+These tests help prevent regressions in:
+
+1. **Exporting Signed PDFs**
+   - Signature placement coordinates
+   - Signature rendering with fonts
+   - Signature size and position
+
+2. **Editing Annotations**
+   - Highlight CRUD operations
+   - Color persistence
+   - Text annotations
+   - Comment bubbles
+
+3. **Drawing Functionality**
+   - Freehand drawing paths
+   - Drawing persistence across sessions
+   - Page-specific drawings
+   - Drawing deletion
+
+4. **Signature Features**
+   - Drawing signatures on canvas
+   - Typing signatures with fonts
+   - Signature validation
+   - Save/load signature data
+
+### Database Schema
+
+The tests validate the following tables:
+
+**pdf_highlights**:
+- id (INTEGER PRIMARY KEY)
+- file_path (TEXT NOT NULL)
+- highlighted_text (TEXT NOT NULL)
+- position_json (TEXT NOT NULL)
+- annotation (TEXT DEFAULT '')
+- color (TEXT DEFAULT 'yellow')
+- timestamp (DATETIME)
+
+**pdf_drawings**:
+- id (INTEGER PRIMARY KEY)
+- file_path (TEXT NOT NULL)
+- page_index (INTEGER NOT NULL)
+- drawing_type (TEXT DEFAULT 'freehand')
+- svg_path (TEXT NOT NULL)
+- stroke_color (TEXT DEFAULT '#000000')
+- stroke_width (REAL DEFAULT 2)
+- position_x/y (REAL DEFAULT 0)
+- width/height (REAL DEFAULT 100)
+- timestamp (DATETIME)


### PR DESCRIPTION

- Terminal source profile: Changed from one-time prompt key to tri-state AUTO_SOURCE_KEY ('true'/'false'/unset). 'Source Profile' sets 'true' and auto-runs on new terminals. 'Dismiss' sets 'false' and suppresses the prompt.

- Recently opened folders: Added file-based storage (recent_paths.json in INCOGNIDE_HOME) with IPC APIs (getRecentPaths, setRecentPaths, addRecentPath) so recent paths survive localStorage/sessionStorage clearing on app restart. Enpistu.tsx now loads from file on mount and syncs to file on change.

- Tabs vs panes: Already persisted via localStorage (incognide_openMode). No change needed.

