### PR TITLE
fix: replace deprecated Clerk redirectUrl with fallbackRedirectUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incognide",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Explore the unknown, build the future, own your data.",
   "author": "Chris Agostino <info@npcworldwi.de>",
   "license": "MIT",

--- a/src/renderer/components/AccountPane.tsx
+++ b/src/renderer/components/AccountPane.tsx
@@ -104,7 +104,7 @@ const AccountPane: React.FC<AccountPaneProps> = ({ nodeId }) => {
                                 </div>
                                 <p className="text-sm mb-1">Not signed in</p>
                                 <p className="text-xs theme-text-muted mb-4">Sign in to encrypt and sync your data across devices.</p>
-                                <button onClick={() => auth.openSignIn({ redirectUrl: window.location.href })} className="inline-flex items-center gap-2 px-5 py-2.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium">
+                                <button onClick={() => auth.openSignIn({ fallbackRedirectUrl: window.location.href })} className="inline-flex items-center gap-2 px-5 py-2.5 text-sm bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-medium">
                                     <LogIn size={16} /> Sign In
                                 </button>
                             </div>

--- a/src/renderer/components/AuthProvider.tsx
+++ b/src/renderer/components/AuthProvider.tsx
@@ -342,7 +342,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 signOut,
                 refreshUser,
                 getToken,
-                openSignIn: () => clerk.openSignIn({ redirectUrl: window.location.href }),
+                openSignIn: () => clerk.openSignIn({ fallbackRedirectUrl: window.location.href }),
                 openUserProfile: () => clerk.openUserProfile(),
                 error
             }}

--- a/src/renderer/components/UserMenu.tsx
+++ b/src/renderer/components/UserMenu.tsx
@@ -273,14 +273,14 @@ const UserMenu: React.FC<UserMenuProps> = ({ onOpenSettings, compact = false }) 
             <>
                 <div className="flex flex-col gap-2 w-full">
                     <button
-                        onClick={() => openSignIn({ redirectUrl: window.location.href })}
+                        onClick={() => openSignIn({ fallbackRedirectUrl: window.location.href })}
                         className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors"
                     >
                         <LogIn size={16} />
                         <span className="text-sm font-medium">Sign In</span>
                     </button>
                     <button
-                        onClick={() => openSignUp({ redirectUrl: window.location.href })}
+                        onClick={() => openSignUp({ fallbackRedirectUrl: window.location.href })}
                         className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-lg border border-gray-600 hover:bg-gray-700/50 text-gray-300 transition-colors"
                     >
                         <User size={16} />


### PR DESCRIPTION
Fix Clerk 422 by replacing deprecated `redirectUrl` with `fallbackRedirectUrl`.