### PR TITLE
fix(main): expand frame-src CSP for Clerk auth iframes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2440,7 +2440,7 @@ applyAppMenu();
         "img-src 'self' data: file: media: blob: http: https:; " +
         "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; " +
         `connect-src 'self' file: media: http://localhost:${FRONTEND_PORT} http://127.0.0.1:${BACKEND_PORT} ${BACKEND_URL} blob: ws: wss: https://* http://*; ` +
-        "frame-src 'self' file: data: blob: media: chrome-extension: https://js.stripe.com https://m.stripe.network https://checkout.stripe.com https://*.clerk.accounts.dev https://clerk.app.incognide.com; " +
+        "frame-src 'self' file: data: blob: media: chrome-extension: https://js.stripe.com https://m.stripe.network https://checkout.stripe.com https://*.clerk.accounts.dev https://clerk.app.incognide.com https://accounts.youtube.com https://accounts.google.com https://www.google.com https://www.gstatic.com; " +
         "object-src 'self' file: data: blob: media: chrome-extension:; " +
         "worker-src 'self' blob: data:; " +
         "media-src 'self' data: file: blob: http: https:;"


### PR DESCRIPTION
## Summary
Fixes CSP blocking Clerk's sign-in flow in production. Clerk loads Google/YouTube iframes for social login and CAPTCHA.

## Changes
- Add `https://accounts.youtube.com`, `https://accounts.google.com`, `https://www.google.com`, `https://www.gstatic.com` to `frame-src` directive.
- Update `CLERK_PUBLISHABLE_KEY` GitHub secret to production `pk_live_*` key.

## Test plan
- [ ] Build production app
- [ ] Click Sign In
- [ ] Verify Clerk modal loads without CSP errors
- [ ] Complete sign-in flow