### PR TITLE
editor context menu cleanup, add-to-chat/agent, vim panel and bottom bar fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incognide",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Explore the unknown, build the future, own your data.",
   "author": "Chris Agostino <info@npcworldwi.de>",
   "license": "MIT",

--- a/src/renderer/components/AgentInput.tsx
+++ b/src/renderer/components/AgentInput.tsx
@@ -72,6 +72,7 @@ interface AgentInputProps {
     setContextPaneOverrides: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
     contentDataRef: React.MutableRefObject<any>;
     paneVersion?: number;
+    paneUpdateEmitter?: EventTarget;
 
     executionMode: string;
     setExecutionMode: (val: string) => void;
@@ -142,7 +143,8 @@ const AgentInput: React.FC<AgentInputProps> = (props) => {
         selectedModels, setSelectedModels, selectedNPCs, setSelectedNPCs,
         broadcastMode, setBroadcastMode,
         availableMcpServers,
-        activeConversationId, onFocus, onOpenFile, onBroadcast
+        activeConversationId, onFocus, onOpenFile, onBroadcast,
+        paneUpdateEmitter
     } = props;
 
     const [isHovering, setIsHovering] = useState(false);
@@ -167,6 +169,19 @@ const AgentInput: React.FC<AgentInputProps> = (props) => {
             }
         } catch {}
     }, [localInput, paneId]);
+    useEffect(() => {
+        if (!paneUpdateEmitter) return;
+        const handlePaneUpdate = (e: any) => {
+            if (e.detail?.paneId === paneId || e.detail?.paneId === 'all') {
+                const refInput = contentDataRef?.current?.[paneId]?.localInput;
+                if (refInput !== undefined && refInput !== localInput) {
+                    setLocalInput(refInput);
+                }
+            }
+        };
+        paneUpdateEmitter.addEventListener('pane-update', handlePaneUpdate);
+        return () => paneUpdateEmitter.removeEventListener('pane-update', handlePaneUpdate);
+    }, [paneUpdateEmitter, paneId, localInput]);
     const [isInputMinimized, setIsInputMinimized] = useState(false);
     const [isInputExpanded, setIsInputExpanded] = useState(false);
     const [uploadedFiles, setUploadedFiles] = useState<any[]>(() => {

--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -72,6 +72,7 @@ interface ChatInputProps {
     setContextPaneOverrides: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
     contentDataRef: React.MutableRefObject<any>;
     paneVersion?: number;
+    paneUpdateEmitter?: EventTarget;
 
     executionMode: string;
     setExecutionMode: (val: string) => void;
@@ -142,7 +143,8 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
         selectedModels, setSelectedModels, selectedNPCs, setSelectedNPCs,
         broadcastMode, setBroadcastMode,
         availableMcpServers,
-        activeConversationId, onFocus, onOpenFile, onBroadcast
+        activeConversationId, onFocus, onOpenFile, onBroadcast,
+        paneUpdateEmitter
     } = props;
 
     const [isHovering, setIsHovering] = useState(false);
@@ -167,6 +169,19 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
             }
         } catch {}
     }, [localInput, paneId]);
+    useEffect(() => {
+        if (!paneUpdateEmitter) return;
+        const handlePaneUpdate = (e: any) => {
+            if (e.detail?.paneId === paneId || e.detail?.paneId === 'all') {
+                const refInput = contentDataRef?.current?.[paneId]?.localInput;
+                if (refInput !== undefined && refInput !== localInput) {
+                    setLocalInput(refInput);
+                }
+            }
+        };
+        paneUpdateEmitter.addEventListener('pane-update', handlePaneUpdate);
+        return () => paneUpdateEmitter.removeEventListener('pane-update', handlePaneUpdate);
+    }, [paneUpdateEmitter, paneId, localInput]);
     const [isInputMinimized, setIsInputMinimized] = useState(false);
     const [isInputExpanded, setIsInputExpanded] = useState(false);
     const [uploadedFiles, setUploadedFiles] = useState<any[]>(() => {

--- a/src/renderer/components/CodeEditor.tsx
+++ b/src/renderer/components/CodeEditor.tsx
@@ -19,7 +19,7 @@ import { EditorState } from '@codemirror/state';
 import { tags as t } from '@lezer/highlight';
 import { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { lintKeymap, linter, lintGutter, type Diagnostic } from '@codemirror/lint';
-import { BrainCircuit, Edit, FileText, MessageSquare, GitBranch, X, Play, HelpCircle, RefreshCw } from 'lucide-react';
+import { Edit, FileText, MessageSquare, GitBranch, X, Play, HelpCircle, RefreshCw, ChevronDown, Bot } from 'lucide-react';
 
 const appHighlightStyleDark = HighlightStyle.define([
     { tag: t.keyword, color: '#c678dd' },
@@ -190,11 +190,17 @@ const editorThemeDark = EditorView.theme({
     },
 
     '.cm-vim-panel': {
-        backgroundColor: '#181825',
+        backgroundColor: '#0f0f14',
         color: '#cdd6f4',
-        padding: '2px 8px',
+        padding: '4px 12px',
         fontFamily: '"Fira Code", monospace',
-        fontSize: '12px',
+        fontSize: '13px',
+        borderTop: '1px solid #313244',
+        width: '100%',
+        boxSizing: 'border-box',
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: '26px',
     },
     '.cm-vim-panel input': {
         backgroundColor: 'transparent',
@@ -202,6 +208,9 @@ const editorThemeDark = EditorView.theme({
         border: 'none',
         outline: 'none',
         fontFamily: '"Fira Code", monospace',
+        fontSize: '13px',
+        flex: '1',
+        marginLeft: '8px',
     },
 
     '&.cm-focused .cm-fat-cursor': {
@@ -356,11 +365,17 @@ const editorThemeLight = EditorView.theme({
         marginRight: '0.5em',
     },
     '.cm-vim-panel': {
-        backgroundColor: '#f3f4f6',
+        backgroundColor: '#f9fafb',
         color: '#374151',
-        padding: '2px 8px',
+        padding: '4px 12px',
         fontFamily: '"Fira Code", monospace',
-        fontSize: '12px',
+        fontSize: '13px',
+        borderTop: '1px solid #e5e7eb',
+        width: '100%',
+        boxSizing: 'border-box',
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: '26px',
     },
     '.cm-vim-panel input': {
         backgroundColor: 'transparent',
@@ -368,6 +383,9 @@ const editorThemeLight = EditorView.theme({
         border: 'none',
         outline: 'none',
         fontFamily: '"Fira Code", monospace',
+        fontSize: '13px',
+        flex: '1',
+        marginLeft: '8px',
     },
     '&.cm-focused .cm-fat-cursor': {
         background: '#2563eb !important',
@@ -728,6 +746,7 @@ const CodeEditorPane = ({
     handleEditorCopy,
     handleEditorPaste,
     handleAddToChat,
+    handleAddToAgent,
     handleAIEdit,
     startAgenticEdit,
     setPromptModal,
@@ -752,6 +771,8 @@ const CodeEditorPane = ({
     });
     const [showKeybindGuide, setShowKeybindGuide] = useState(false);
     const [diskChangeContent, setDiskChangeContent] = useState<string | null>(null);
+    const [showModeDropdown, setShowModeDropdown] = useState(false);
+    const [refreshTick, setRefreshTick] = useState(0);
 
     useEffect(() => {
         const handleCycleMode = (e: KeyboardEvent) => {
@@ -899,6 +920,7 @@ const CodeEditorPane = ({
                 pd.fileContent = diskContent;
                 pd.fileChanged = false;
                 setRootLayoutNode(p => ({ ...p }));
+                setRefreshTick(prev => prev + 1);
             }
         } catch (e) {
             console.error('[CodeEditor] Reload failed:', e);
@@ -1032,56 +1054,52 @@ const CodeEditorPane = ({
                         savedEditorState={paneData?._scrollTopPos != null ? { scrollTopPos: paneData._scrollTopPos } : undefined}
                         onEditorStateChange={(state) => { if (paneData) { paneData._scrollTopPos = state.scrollTopPos; } }}
                     />
-                    <div className="absolute bottom-1 right-2 z-10 flex items-center gap-1">
-                        {(['default', 'vim', 'emacs', 'nano'] as const).map(mode => {
-                            const isEnabled = enabledModes.includes(mode);
-                            const isActive = keybindMode === mode;
-                            const label = mode === 'default' ? 'Def' : mode.charAt(0).toUpperCase() + mode.slice(1);
-                            return (
-                                <button
-                                    key={mode}
-                                    onClick={() => {
-
-                                        setKeybindMode(mode);
-                                        localStorage.setItem('incognide_editorKeybindMode', mode);
-
-                                        if (!isEnabled) {
-                                            const next = [...enabledModes, mode];
-                                            setEnabledModes(next);
-                                            localStorage.setItem('incognide_editorEnabledModes', JSON.stringify(next));
-                                        }
-                                    }}
-                                    onContextMenu={(e) => {
-                                        e.preventDefault();
-
-                                        if (isEnabled && enabledModes.length > 1) {
-                                            const next = enabledModes.filter(m => m !== mode);
-                                            setEnabledModes(next);
-                                            localStorage.setItem('incognide_editorEnabledModes', JSON.stringify(next));
-
-                                            if (keybindMode === mode) {
-                                                setKeybindMode(next[0]);
-                                                localStorage.setItem('incognide_editorKeybindMode', next[0]);
-                                            }
-                                        } else if (!isEnabled) {
-                                            const next = [...enabledModes, mode];
-                                            setEnabledModes(next);
-                                            localStorage.setItem('incognide_editorEnabledModes', JSON.stringify(next));
-                                        }
-                                    }}
-                                    className={`text-[10px] px-1.5 py-0.5 rounded border cursor-pointer transition-colors ${
-                                        isActive
-                                            ? 'bg-purple-600/60 text-purple-200 border-purple-500/50'
-                                            : isEnabled
-                                                ? 'bg-black/40 text-gray-400 border-white/10 hover:bg-black/60 hover:text-gray-200'
-                                                : 'bg-black/20 text-gray-600 border-white/5 hover:bg-black/40 hover:text-gray-400'
-                                    }`}
-                                    title={`${isActive ? 'Active' : 'Click to switch'}. Right-click to ${isEnabled ? 'exclude from' : 'include in'} Ctrl+Shift+Space cycle.`}
-                                >
-                                    {label}
-                                </button>
-                            );
-                        })}
+                    <div className="absolute bottom-1 right-2 z-10 flex items-center gap-2">
+                        <span className="text-[10px] text-gray-500 font-mono select-none">
+                            {(fileContent || '').split('\n').length} lines
+                        </span>
+                        <div className="relative">
+                            <button
+                                onClick={() => setShowModeDropdown(prev => !prev)}
+                                className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded border bg-black/40 text-gray-300 border-white/10 hover:bg-black/60 hover:text-gray-100 cursor-pointer transition-colors"
+                                title="Click to switch keybinding mode. Ctrl+Shift+Space to cycle."
+                            >
+                                {keybindMode === 'default' ? 'Default' : keybindMode.charAt(0).toUpperCase() + keybindMode.slice(1)}
+                                <ChevronDown size={10} />
+                            </button>
+                            {showModeDropdown && (
+                                <>
+                                    <div className="fixed inset-0 z-[9997]" onClick={() => setShowModeDropdown(false)} />
+                                    <div className="absolute bottom-full right-0 mb-1 z-[9998] theme-bg-secondary theme-border border rounded shadow-lg py-1 min-w-[120px]">
+                                        {(['default', 'vim', 'emacs', 'nano'] as const).map(mode => {
+                                            const isEnabled = enabledModes.includes(mode);
+                                            const isActive = keybindMode === mode;
+                                            return (
+                                                <button
+                                                    key={mode}
+                                                    onClick={() => {
+                                                        setKeybindMode(mode);
+                                                        localStorage.setItem('incognide_editorKeybindMode', mode);
+                                                        setShowModeDropdown(false);
+                                                        if (!isEnabled) {
+                                                            const next = [...enabledModes, mode];
+                                                            setEnabledModes(next);
+                                                            localStorage.setItem('incognide_editorEnabledModes', JSON.stringify(next));
+                                                        }
+                                                    }}
+                                                    className={`flex items-center justify-between gap-2 px-3 py-1.5 theme-hover w-full text-left text-xs ${
+                                                        isActive ? 'text-purple-300' : 'theme-text-primary'
+                                                    }`}
+                                                >
+                                                    <span>{mode === 'default' ? 'Default' : mode.charAt(0).toUpperCase() + mode.slice(1)}</span>
+                                                    {isActive && <span className="text-purple-400 text-[10px]">●</span>}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </>
+                            )}
+                        </div>
                         <button
                             onClick={reloadFromDisk}
                             className="p-0.5 rounded hover:bg-black/60 text-gray-500 hover:text-gray-300"
@@ -1261,23 +1279,6 @@ const CodeEditorPane = ({
                             className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left theme-text-primary text-sm">
                             Paste
                         </button>
-                        {aiEnabled && contextMenuSelection && (
-                            <>
-                                <div className="border-t theme-border my-1"></div>
-                                <button onClick={() => { handleAIEdit('ask', contextMenuSelection); setEditorContextMenuPos(null); }}
-                                    className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left theme-text-primary text-sm">
-                                    <MessageSquare size={16} />Explain
-                                </button>
-                                <button onClick={() => { handleAIEdit('document', contextMenuSelection); setEditorContextMenuPos(null); }}
-                                    className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left theme-text-primary text-sm">
-                                    <FileText size={16} />Add Comments
-                                </button>
-                                <button onClick={() => { handleAIEdit('edit', contextMenuSelection); setEditorContextMenuPos(null); }}
-                                    className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left theme-text-primary text-sm">
-                                    <Edit size={16} />Refactor
-                                </button>
-                            </>
-                        )}
                         <div className="border-t theme-border my-1"></div>
                         <button
                             onClick={() => {
@@ -1298,6 +1299,14 @@ const CodeEditorPane = ({
                                     className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left text-blue-400 text-sm">
                                     <MessageSquare size={16} />Add to Chat
                                 </button>
+                                <button
+                                    onClick={() => {
+                                        setEditorContextMenuPos(null);
+                                        handleAddToAgent(contextMenuSelection);
+                                    }}
+                                    className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left text-indigo-400 text-sm">
+                                    <Bot size={16} />Add to Agent
+                                </button>
                             </>
                         )}
                         {onSendToTerminal && contextMenuSelection && (
@@ -1310,34 +1319,6 @@ const CodeEditorPane = ({
                                     }}
                                     className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left text-green-400 text-sm">
                                     <Play size={16} />Send to Terminal
-                                </button>
-                            </>
-                        )}
-                        <div className="border-t theme-border my-1"></div>
-                        <button
-                            onClick={() => {
-                                setEditorContextMenuPos(null);
-                                handleStartRename();
-                            }}
-                            className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left theme-text-primary text-sm">
-                            <Edit size={16} />Rename File
-                        </button>
-                        {aiEnabled && (
-                            <>
-                                <div className="border-t theme-border my-1"></div>
-                                <button
-                                    onClick={() => {
-                                        setEditorContextMenuPos(null);
-                                        setPromptModal({
-                                            isOpen: true,
-                                            title: 'Agentic Code Edit',
-                                            message: 'What would you like AI to do with all open files?',
-                                            defaultValue: 'Add error handling and improve code quality',
-                                            onConfirm: (instruction) => startAgenticEdit(instruction)
-                                        });
-                                    }}
-                                    className="flex items-center gap-2 px-4 py-2 theme-hover w-full text-left text-blue-400 text-sm">
-                                    <BrainCircuit size={16} />Agentic Edit
                                 </button>
                             </>
                         )}

--- a/src/renderer/components/CodeEditor.tsx
+++ b/src/renderer/components/CodeEditor.tsx
@@ -772,7 +772,6 @@ const CodeEditorPane = ({
     const [showKeybindGuide, setShowKeybindGuide] = useState(false);
     const [diskChangeContent, setDiskChangeContent] = useState<string | null>(null);
     const [showModeDropdown, setShowModeDropdown] = useState(false);
-    const [refreshTick, setRefreshTick] = useState(0);
 
     useEffect(() => {
         const handleCycleMode = (e: KeyboardEvent) => {
@@ -920,7 +919,6 @@ const CodeEditorPane = ({
                 pd.fileContent = diskContent;
                 pd.fileChanged = false;
                 setRootLayoutNode(p => ({ ...p }));
-                setRefreshTick(prev => prev + 1);
             }
         } catch (e) {
             console.error('[CodeEditor] Reload failed:', e);

--- a/src/renderer/components/Enpistu.tsx
+++ b/src/renderer/components/Enpistu.tsx
@@ -640,7 +640,8 @@ const ChatInterface = ({ onRerunSetup }: { onRerunSetup?: () => void }) => {
     const [renamingPath, setRenamingPath] = useState(null);
     const [editedSidebarItemName, setEditedSidebarItemName] = useState('');
     
-    const [lastActiveChatPaneId, setLastActiveChatPaneId] = useState(null);    
+    const [lastActiveChatPaneId, setLastActiveChatPaneId] = useState(null);
+    const [lastActiveAgentPaneId, setLastActiveAgentPaneId] = useState(null);
     const [aiEditModal, setAiEditModal] = useState({
         isOpen: false,
         type: '',
@@ -655,8 +656,15 @@ const ChatInterface = ({ onRerunSetup }: { onRerunSetup?: () => void }) => {
         modelForEdit: null,
         npcForEdit: null,
         customEditPrompt: ''
-    });    
- 
+    });
+
+    // Track most recently used chat/agent panes
+    useEffect(() => {
+        if (!activeContentPaneId) return;
+        const pd = contentDataRef.current[activeContentPaneId];
+        if (pd?.contentType === 'chat') setLastActiveChatPaneId(activeContentPaneId);
+        if (pd?.contentType === 'agent') setLastActiveAgentPaneId(activeContentPaneId);
+    }, [activeContentPaneId]);
 
     // Sync workspace path to main process for downloads
     useEffect(() => {
@@ -3316,13 +3324,44 @@ const renderFileEditor = useCallback(({ nodeId }) => {
             handleEditorCopy={() => {}}
             handleEditorPaste={() => {}}
             handleAddToChat={(selectedText: string) => {
-                // Get the active pane's file path for context
-                const paneData = contentDataRef.current[activeContentPaneId || ''];
-                const filePath = paneData?.contentId;
+                const editorPaneData = contentDataRef.current[activeContentPaneId || ''];
+                const filePath = editorPaneData?.contentId;
                 const fileName = filePath ? filePath.split('/').pop() : 'selection';
                 const ext = fileName?.split('.').pop() || '';
                 const citation = `\`\`\`${ext}\n// From ${fileName}\n${selectedText}\n\`\`\``;
-                setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                const targetPaneId = lastActiveChatPaneId && contentDataRef.current[lastActiveChatPaneId]?.contentType === 'chat'
+                    ? lastActiveChatPaneId
+                    : Object.keys(contentDataRef.current).find(id => contentDataRef.current[id]?.contentType === 'chat');
+                if (targetPaneId) {
+                    setActiveContentPaneId(targetPaneId);
+                    setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                } else {
+                    const newPaneId = createAndAddPaneNodeToLayout('chat', null);
+                    setTimeout(() => {
+                        setActiveContentPaneId(newPaneId);
+                        setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                    }, 50);
+                }
+            }}
+            handleAddToAgent={(selectedText: string) => {
+                const editorPaneData = contentDataRef.current[activeContentPaneId || ''];
+                const filePath = editorPaneData?.contentId;
+                const fileName = filePath ? filePath.split('/').pop() : 'selection';
+                const ext = fileName?.split('.').pop() || '';
+                const citation = `\`\`\`${ext}\n// From ${fileName}\n${selectedText}\n\`\`\``;
+                const targetPaneId = lastActiveAgentPaneId && contentDataRef.current[lastActiveAgentPaneId]?.contentType === 'agent'
+                    ? lastActiveAgentPaneId
+                    : Object.keys(contentDataRef.current).find(id => contentDataRef.current[id]?.contentType === 'agent');
+                if (targetPaneId) {
+                    setActiveContentPaneId(targetPaneId);
+                    setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                } else {
+                    const newPaneId = createAndAddPaneNodeToLayout('agent', null);
+                    setTimeout(() => {
+                        setActiveContentPaneId(newPaneId);
+                        setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                    }, 50);
+                }
             }}
             handleAIEdit={handleAICodeAction}
             startAgenticEdit={() => {}}
@@ -3333,7 +3372,7 @@ const renderFileEditor = useCallback(({ nodeId }) => {
             onSendToTerminal={handleSendToTerminal}
         />
     );
-}, [activeContentPaneId, setActiveContentPaneId, aiEditModal, renamingPaneId, editedFileName, setRootLayoutNode, currentPath, handleRunScript, handleSendToTerminal, handleAICodeAction]);
+}, [activeContentPaneId, setActiveContentPaneId, aiEditModal, renamingPaneId, editedFileName, setRootLayoutNode, currentPath, handleRunScript, handleSendToTerminal, handleAICodeAction, lastActiveChatPaneId, lastActiveAgentPaneId, createAndAddPaneNodeToLayout, setInput]);
 
 const renderTerminalView = useCallback(({ nodeId, shell }: { nodeId: string, shell?: string }) => {
     return (

--- a/src/renderer/components/Enpistu.tsx
+++ b/src/renderer/components/Enpistu.tsx
@@ -3333,14 +3333,18 @@ const renderFileEditor = useCallback(({ nodeId }) => {
                     ? lastActiveChatPaneId
                     : Object.keys(contentDataRef.current).find(id => contentDataRef.current[id]?.contentType === 'chat');
                 if (targetPaneId) {
+                    const existing = contentDataRef.current[targetPaneId]?.localInput || '';
+                    contentDataRef.current[targetPaneId].localInput = existing ? `${existing}\n\n${citation}` : citation;
                     setActiveContentPaneId(targetPaneId);
-                    setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                    paneUpdateEmitter.dispatchEvent(new CustomEvent('pane-update', { detail: { paneId: targetPaneId } }));
                 } else {
                     const newPaneId = createAndAddPaneNodeToLayout('chat', null);
-                    setTimeout(() => {
+                    if (newPaneId) {
+                        if (!contentDataRef.current[newPaneId].localInput) contentDataRef.current[newPaneId].localInput = '';
+                        contentDataRef.current[newPaneId].localInput = citation;
                         setActiveContentPaneId(newPaneId);
-                        setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
-                    }, 50);
+                        paneUpdateEmitter.dispatchEvent(new CustomEvent('pane-update', { detail: { paneId: newPaneId } }));
+                    }
                 }
             }}
             handleAddToAgent={(selectedText: string) => {
@@ -3353,14 +3357,18 @@ const renderFileEditor = useCallback(({ nodeId }) => {
                     ? lastActiveAgentPaneId
                     : Object.keys(contentDataRef.current).find(id => contentDataRef.current[id]?.contentType === 'agent');
                 if (targetPaneId) {
+                    const existing = contentDataRef.current[targetPaneId]?.localInput || '';
+                    contentDataRef.current[targetPaneId].localInput = existing ? `${existing}\n\n${citation}` : citation;
                     setActiveContentPaneId(targetPaneId);
-                    setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
+                    paneUpdateEmitter.dispatchEvent(new CustomEvent('pane-update', { detail: { paneId: targetPaneId } }));
                 } else {
                     const newPaneId = createAndAddPaneNodeToLayout('agent', null);
-                    setTimeout(() => {
+                    if (newPaneId) {
+                        if (!contentDataRef.current[newPaneId].localInput) contentDataRef.current[newPaneId].localInput = '';
+                        contentDataRef.current[newPaneId].localInput = citation;
                         setActiveContentPaneId(newPaneId);
-                        setInput(prev => `${prev}${prev ? '\n\n' : ''}${citation}`);
-                    }, 50);
+                        paneUpdateEmitter.dispatchEvent(new CustomEvent('pane-update', { detail: { paneId: newPaneId } }));
+                    }
                 }
             }}
             handleAIEdit={handleAICodeAction}
@@ -3372,7 +3380,7 @@ const renderFileEditor = useCallback(({ nodeId }) => {
             onSendToTerminal={handleSendToTerminal}
         />
     );
-}, [activeContentPaneId, setActiveContentPaneId, aiEditModal, renamingPaneId, editedFileName, setRootLayoutNode, currentPath, handleRunScript, handleSendToTerminal, handleAICodeAction, lastActiveChatPaneId, lastActiveAgentPaneId, createAndAddPaneNodeToLayout, setInput]);
+}, [activeContentPaneId, setActiveContentPaneId, aiEditModal, renamingPaneId, editedFileName, setRootLayoutNode, currentPath, handleRunScript, handleSendToTerminal, handleAICodeAction, lastActiveChatPaneId, lastActiveAgentPaneId, createAndAddPaneNodeToLayout, paneUpdateEmitter]);
 
 const renderTerminalView = useCallback(({ nodeId, shell }: { nodeId: string, shell?: string }) => {
     return (
@@ -7678,6 +7686,7 @@ const getChatInputProps = useCallback((paneId: string) => {
     setContextPaneOverrides: (updater: any) => { setContextPaneOverrides(updater); notifyUpdate(); },
     contentDataRef,
     paneVersion,
+    paneUpdateEmitter,
     // Per-pane execution mode
     executionMode: getPaneExecutionMode(paneId),
     setExecutionMode: (mode: string) => { setPaneExecutionMode(paneId, mode); notifyUpdate(); },

--- a/src/renderer/components/Enpistu.tsx
+++ b/src/renderer/components/Enpistu.tsx
@@ -3324,7 +3324,7 @@ const renderFileEditor = useCallback(({ nodeId }) => {
             handleEditorCopy={() => {}}
             handleEditorPaste={() => {}}
             handleAddToChat={(selectedText: string) => {
-                const editorPaneData = contentDataRef.current[activeContentPaneId || ''];
+                const editorPaneData = contentDataRef.current[nodeId];
                 const filePath = editorPaneData?.contentId;
                 const fileName = filePath ? filePath.split('/').pop() : 'selection';
                 const ext = fileName?.split('.').pop() || '';
@@ -3348,7 +3348,7 @@ const renderFileEditor = useCallback(({ nodeId }) => {
                 }
             }}
             handleAddToAgent={(selectedText: string) => {
-                const editorPaneData = contentDataRef.current[activeContentPaneId || ''];
+                const editorPaneData = contentDataRef.current[nodeId];
                 const filePath = editorPaneData?.contentId;
                 const fileName = filePath ? filePath.split('/').pop() : 'selection';
                 const ext = fileName?.split('.').pop() || '';


### PR DESCRIPTION
- Clean up code editor context menu (remove Explain, Add Comments, Refactor, Rename File, Agentic Edit)
- Add 'Add to Chat' and 'Add to Agent' right-click options that route to the most recently used pane
- Fix 'Send to Terminal' right-click option
- Replace 4 keybinding mode bubbles with a single dropdown + line count in bottom bar
- Fix reload button to work without wiggling the pane
- Improve vim panel styling as a proper status bar
- Bump version to 0.2.11